### PR TITLE
fix pm list view - add in componentwillunmount

### DIFF
--- a/components/PMList.js
+++ b/components/PMList.js
@@ -19,7 +19,12 @@ export default class PMList extends React.Component {
         chatrooms: [...this.state.chatrooms, room],
         grabbed: true
       })
-  }));
+    }));
+  }
+
+
+  componentWillUnmount() {
+    Fire.shared.off()
   }
 
   getRoomName(name) {


### PR DESCRIPTION
componentWillUnmount function was accidentally removed from PMList causing issues when going back and forth between main chatroom view and PM chat view. 