### PR TITLE
Partner chatlist

### DIFF
--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -2,9 +2,9 @@
   "expoServerPort": 19000,
   "expoServerNgrokUrl": "https://3r-rqp.malkam.zoot.exp.direct",
   "packagerNgrokUrl": "https://packager.3r-rqp.malkam.zoot.exp.direct",
-  "ngrokPid": 712,
+  "ngrokPid": 5752,
   "devToolsPort": 19002,
   "packagerPort": 19001,
-  "packagerPid": 700,
+  "packagerPid": 5738,
   "webpackServerPort": null
 }

--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -1,10 +1,10 @@
 {
   "expoServerPort": 19000,
-  "expoServerNgrokUrl": "https://3r-rqp.malkam.zoot.exp.direct",
-  "packagerNgrokUrl": "https://packager.3r-rqp.malkam.zoot.exp.direct",
-  "ngrokPid": 16739,
+  "expoServerNgrokUrl": null,
+  "packagerNgrokUrl": null,
+  "ngrokPid": null,
   "devToolsPort": 19002,
   "packagerPort": 19001,
-  "packagerPid": 16725,
+  "packagerPid": 23969,
   "webpackServerPort": null
 }

--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -2,9 +2,9 @@
   "expoServerPort": 19000,
   "expoServerNgrokUrl": "https://3r-rqp.malkam.zoot.exp.direct",
   "packagerNgrokUrl": "https://packager.3r-rqp.malkam.zoot.exp.direct",
-  "ngrokPid": 5752,
+  "ngrokPid": 16739,
   "devToolsPort": 19002,
   "packagerPort": 19001,
-  "packagerPid": 5738,
+  "packagerPid": 16725,
   "webpackServerPort": null
 }

--- a/.expo/settings.json
+++ b/.expo/settings.json
@@ -3,6 +3,6 @@
   "lanType": "ip",
   "dev": true,
   "minify": false,
-  "urlRandomness": "3r-rqp",
+  "urlRandomness": "mg-3b6",
   "https": false
 }

--- a/App.js
+++ b/App.js
@@ -54,8 +54,7 @@ const navigator = createStackNavigator(
   {
     headerMode: 'none',
     navigationOptions: {
-      headerVisible: false,
-      unmountInactiveRoutes: true
+      headerVisible: false
     }
   }
 );

--- a/App.js
+++ b/App.js
@@ -54,7 +54,8 @@ const navigator = createStackNavigator(
   {
     headerMode: 'none',
     navigationOptions: {
-      headerVisible: false
+      headerVisible: false,
+      unmountInactiveRoutes: true
     }
   }
 );

--- a/Fire.js
+++ b/Fire.js
@@ -376,10 +376,18 @@ class Fire {
         return status;
       });
 
-  getChatRoomNames = (callback) =>
+  getChatRoomNames = (callback, partner) => {
+    let ref = partner ? `partnerChatroomNames/${partner}` : 'chatroomnames';
     firebase
       .database()
-      .ref('chatroomnames')
+      .ref(ref)
+      .on('child_added', (snapshot) => callback(this.parseRooms(snapshot)));
+  };
+
+  getPartnerChatRoomNames = (callback, partner) =>
+    firebase
+      .database()
+      .ref(`partnerChatroomNames/${partner}`)
       .on('child_added', (snapshot) => callback(this.parseRooms(snapshot)));
 
   removeChatRooms = (callback) =>
@@ -593,6 +601,13 @@ class Fire {
     firebase
       .database()
       .ref('chatroomnames')
+      .on('child_changed', (snapshot) => callback(snapshot.val()));
+  };
+
+  getUpdatedPartnerNumOnline = (callback) => {
+    firebase
+      .database()
+      .ref('partnerChatroomNames')
       .on('child_changed', (snapshot) => callback(snapshot.val()));
   };
 

--- a/components/ChatList.js
+++ b/components/ChatList.js
@@ -29,16 +29,19 @@ export default class ChatList extends React.Component {
       partner: null
     };
   }
-
-  componentDidMount() {
-    this.focusListener = this.props.navigation.addListener('didFocus', () => {
-      if (this.props.navigation.getParam('partner')) {
-        this.setState({partner: this.props.navigation.getParam('partner')});
-      }
-    });
-  }
-
-  componentWillMount() {
+  // EV: this was component Will Mount - had to change it to "did" because otherwise it can't update state (apparently you can't do that from an unmounted component). This was eventually what worked! It still gave me a warning, but it also worked.
+  async componentDidMount() {
+    // This updates the partner property in the state successfully
+    const {params} = this.props.navigation.state;
+    console.log({params});
+    if (params) {
+      const partner = params.partner ? params.partner : null;
+      await this.setState(
+        {partner: partner},
+        console.log('partner in state at line 40, ', this.state.partner)
+      );
+    }
+    // EV: One thing I tried to do is add the partner (from state) to the arguments of Fire.shared.getChatroomNames, then adding it to the function in fire.js (see there, line 379).
     // grab chatrooms = every room has a name and numOnline attribute
     Fire.shared.getChatRoomNames((newRoom) => {
       const queriedChatrooms = this.state.queriedChatrooms;
@@ -57,7 +60,7 @@ export default class ChatList extends React.Component {
           a.name > b.name ? 1 : -1
         )
       });
-    });
+    }, this.state.partner);
 
     // update numOnline as it changes in database
     Fire.shared.getUpdatedNumOnline((updatedRoom) => {

--- a/components/ChatList.js
+++ b/components/ChatList.js
@@ -26,15 +26,19 @@ export default class ChatList extends React.Component {
       chatrooms: [],
       queriedChatrooms: [],
       query: '',
-      partner: this.props.navigation.getParam('partner') || null
+      partner: null
     };
   }
 
+  componentDidMount() {
+    this.focusListener = this.props.navigation.addListener('didFocus', () => {
+      if (this.props.navigation.getParam('partner')) {
+        this.setState({partner: this.props.navigation.getParam('partner')});
+      }
+    });
+  }
+
   componentWillMount() {
-    console.log(
-      'what params looks like, ',
-      this.props.navigation.getParam('partner')
-    );
     // grab chatrooms = every room has a name and numOnline attribute
     Fire.shared.getChatRoomNames((newRoom) => {
       const queriedChatrooms = this.state.queriedChatrooms;

--- a/components/ChatList.js
+++ b/components/ChatList.js
@@ -45,21 +45,24 @@ export default class ChatList extends React.Component {
     // grab chatrooms = every room has a name and numOnline attribute
     Fire.shared.getChatRoomNames((newRoom) => {
       const queriedChatrooms = this.state.queriedChatrooms;
+      if (newRoom.name) {
+        if (
+          newRoom.name.toLowerCase().includes(this.state.query.toLowerCase())
+        ) {
+          queriedChatrooms.push(newRoom);
+        }
 
-      // add room to querried rooms if query matches
-      if (newRoom.name.toLowerCase().includes(this.state.query.toLowerCase())) {
-        queriedChatrooms.push(newRoom);
+        // update state
+        this.setState({
+          chatrooms: [...this.state.chatrooms, newRoom].sort((a, b) =>
+            a.name > b.name ? 1 : -1
+          ),
+          queriedChatrooms: queriedChatrooms.sort((a, b) =>
+            a.name > b.name ? 1 : -1
+          )
+        });
       }
-
-      // update state
-      this.setState({
-        chatrooms: [...this.state.chatrooms, newRoom].sort((a, b) =>
-          a.name > b.name ? 1 : -1
-        ),
-        queriedChatrooms: queriedChatrooms.sort((a, b) =>
-          a.name > b.name ? 1 : -1
-        )
-      });
+      // add room to querried rooms if query matches
     }, this.state.partner);
 
     // update numOnline as it changes in database
@@ -142,6 +145,10 @@ export default class ChatList extends React.Component {
     const diff = date.getTime() - invdate.getTime();
     return new Date(date.getTime() + diff);
   };
+
+  componentWillUnmount() {
+    console.log('unmount firing >>>>>>>');
+  }
 
   communityPopup = (timeToAcceptableFirebaseString) => {
     Alert.alert(

--- a/components/PartnerList.js
+++ b/components/PartnerList.js
@@ -31,16 +31,24 @@ export class PartnerList extends Component {
     // console.log('partners', partners);
     // this.setState({partnerNames: partners});
     // Fire.shared.getPartnerNames(this.setPartnersToState());
-    let partners = await this.getPartnerNames();
-    this.setState({partnerNames: Object.keys(partners)});
+    try {
+      let partners = await this.getPartnerNames();
+      this.setState({partnerNames: Object.keys(partners)});
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   async getPartnerNames() {
     let ref = firebase.database().ref(`partnerNames`);
-    let query = await ref.once('value').then(function (snapshot) {
-      return snapshot.val();
-    });
-    return query;
+    try {
+      let query = await ref.once('value').then(function (snapshot) {
+        return snapshot.val();
+      });
+      return query;
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   render() {

--- a/components/PartnerList.js
+++ b/components/PartnerList.js
@@ -12,6 +12,11 @@ import {Searchbar} from 'react-native-paper';
 import {MaterialIndicator} from 'react-native-indicators';
 import {Ionicons} from '@expo/vector-icons';
 import * as firebase from 'firebase';
+import {
+  StackActions,
+  NavigationActions,
+  withNavigation
+} from 'react-navigation';
 
 import Navbar from './Navbar';
 import ChatList from './ChatList';
@@ -22,15 +27,12 @@ export class PartnerList extends Component {
     this.state = {
       partnerNames: [],
       queriedPartners: [],
-      query: ''
+      query: '',
+      selectedPartnerChatrooms: {}
     };
   }
 
   async componentDidMount() {
-    // const partners = await this.getPartnerNames();
-    // console.log('partners', partners);
-    // this.setState({partnerNames: partners});
-    // Fire.shared.getPartnerNames(this.setPartnersToState());
     try {
       let partners = await this.getPartnerNames();
       this.setState({partnerNames: Object.keys(partners)});
@@ -50,6 +52,27 @@ export class PartnerList extends Component {
       console.error(error);
     }
   }
+
+  resetNavigation() {
+    const resetAction = StackActions.reset({
+      index: 0,
+      actions: [NavigationActions.navigate({routeName: 'ChatList'})]
+    });
+    this.props.navigation.dispatch(resetAction);
+  }
+
+  // EV: it occurred to me here to load the partner's chatrooms on the partnerlist page. This didn't work because it required calling an async function when navigating (to pull up the chatrooms of the board that was clicked). I'm not sure why, but as soon as I did that, both navigation params (partner name and the actual chatlist) disappeared.
+  // async getPartnerChatlist(partner) {
+  //   let ref = firebase.database().ref(`partnerChatroomNames/${partner}`);
+  //   try {
+  //     let query = await ref.once('value').then(function (snapshot) {
+  //       return snapshot.val();
+  //     });
+  //     this.setState({selectedPartnerChatrooms: query});
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // }
 
   render() {
     console.log(this.state.partnerNames, 'partner names in state');
@@ -111,11 +134,15 @@ export class PartnerList extends Component {
                     <TouchableOpacity
                       key={partner}
                       style={styles.buttonContainer}
-                      onPress={() =>
+                      onPress={() => {
+                        this.resetNavigation();
+                        this.getPartnerChatlist();
                         this.props.navigation.navigate('ChatList', {
                           partner: partner
-                        })
-                      }
+                          // EV: if you leave in line 144, it'll pass a promise. If you await it, it'll pass nothing at all.
+                          // chatrooms: this.state.selectedPartnerChatrooms
+                        });
+                      }}
                     >
                       <View style={styles.singleChatView}>
                         <Text style={styles.buttonText}># {partner}</Text>
@@ -217,4 +244,4 @@ const styles = StyleSheet.create({
   }
 });
 
-export default PartnerList;
+export default withNavigation(PartnerList);

--- a/components/PartnerList.js
+++ b/components/PartnerList.js
@@ -136,7 +136,8 @@ export class PartnerList extends Component {
                       style={styles.buttonContainer}
                       onPress={() => {
                         this.resetNavigation();
-                        this.getPartnerChatlist();
+                        // EV:line 140 is also an async function
+                        // this.getPartnerChatlist();
                         this.props.navigation.navigate('ChatList', {
                           partner: partner
                           // EV: if you leave in line 144, it'll pass a promise. If you await it, it'll pass nothing at all.
@@ -145,7 +146,9 @@ export class PartnerList extends Component {
                       }}
                     >
                       <View style={styles.singleChatView}>
-                        <Text style={styles.buttonText}># {partner}</Text>
+                        <Text style={styles.buttonText}>
+                          {`\u2022 ${partner}`}
+                        </Text>
                         <Ionicons name="md-people" size={25} color="grey">
                           {' '}
                         </Ionicons>


### PR DESCRIPTION
* Navigating from the partner list to the chatlist now resets the navigation stack
* Thanks to that, the chatlist unmounts, and componentDidMount fires when navigating back to it (I couldn't achieve this effect using onFocus, not sure why)
* A partner property has been added to the chatlist component and updates on componentDidMount. If it's null, the firebase path referred to is the regular chatroomnames path; if it's not null, the path used is the parnter chatlist of that partner.